### PR TITLE
ci: increase fuzz case sizes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,7 +63,6 @@ jobs:
         run: >
           cargo +nightly fuzz run $FUZZ_TARGET --
           -max_total_time=120
-          -max_len=1022
 
       - name: Upload crash
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Before only 1022 bytes were being parsed.

---

* ci: increase fuzz case sizes (71b21c4)
      
      Increase the maximum size of fuzz test cases to the default libfuzzer
      value.