### PR TITLE
Fix AuthFlavor serialised_len and simplify Opaque serialization

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hex_literal::hex;
 use onc_rpc::{
     auth::{AuthFlavor, AuthUnixParams},
-    Bytes, CallBody, MessageType, RpcMessage,
+    Bytes, CallBody, MessageType, Opaque, RpcMessage,
 };
 
 pub fn auth(c: &mut Criterion) {
@@ -20,7 +20,7 @@ pub fn auth(c: &mut Criterion) {
         let raw_ref: &[u8] = raw.as_ref();
 
         b.iter(|| {
-            let a: AuthFlavor<&[u8]> = raw_ref.try_into().unwrap();
+            let a: AuthFlavor<Opaque<&[u8]>> = raw_ref.try_into().unwrap();
             black_box(a)
         })
     });
@@ -43,7 +43,7 @@ pub fn auth(c: &mut Criterion) {
         let raw_ref: &[u8] = raw.as_ref();
 
         b.iter(|| {
-            let a: AuthFlavor<&[u8]> = raw_ref.try_into().unwrap();
+            let a: AuthFlavor<Opaque<&[u8]>> = raw_ref.try_into().unwrap();
             black_box(a)
         })
     });
@@ -86,7 +86,7 @@ pub fn rpc_message(c: &mut Criterion) {
         let gids = [
             501, 12, 20, 61, 79, 80, 81, 98, 701, 33, 100, 204, 250, 395, 398, 399,
         ];
-        let params = AuthUnixParams::new(0, "", 501, 20, gids);
+        let params = AuthUnixParams::new(0, Opaque::from("".as_ref()), 501, 20, gids);
         let payload = vec![];
         let msg = RpcMessage::new(
             4242,

--- a/src/auth/unix_params.rs
+++ b/src/auth/unix_params.rs
@@ -80,7 +80,7 @@ where
     gids: Gids,
 }
 
-impl<'a> AuthUnixParams<Opaque<'a, &'a [u8]>> {
+impl<'a> AuthUnixParams<Opaque<&'a [u8]>> {
     /// Constructs a new `AuthUnixParams` by parsing the wire format read from
     /// `r`, validating it has read exactly `expected_len` number of bytes.
     ///
@@ -164,6 +164,8 @@ where
     pub fn serialise_into<W: Write>(&self, mut buf: W) -> Result<(), std::io::Error> {
         buf.write_u32::<BigEndian>(self.stamp)?;
         let opaque = Opaque::from(self.machine_name.as_ref());
+        let machine_name_len = opaque.len() as u32;// length header for opaque
+        buf.write_u32::<BigEndian>(machine_name_len)?;
         opaque.serialise_into(&mut buf)?;
         buf.write_u32::<BigEndian>(self.uid)?;
         buf.write_u32::<BigEndian>(self.gid)?;
@@ -225,7 +227,7 @@ where
 
         // machine_name length 
         let opaque = Opaque::from(self.machine_name.as_ref());
-        l += opaque.serialised_len() as usize;
+        l += opaque.serialised_len() as usize + 4;// length header takes 4 byte
 
         // gids length prefix u32 + values
         l += (self.gids.deref().len() + 1) * std::mem::size_of::<u32>();

--- a/src/call_body.rs
+++ b/src/call_body.rs
@@ -29,7 +29,7 @@ where
     payload: P,
 }
 
-impl<'a> CallBody<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> CallBody<Opaque<&'a [u8]>, &'a [u8]> {
     /// Constructs a new `CallBody` by parsing the wire format read from `r`.
     ///
     /// `from_cursor` advances the position of `r` to the end of the `CallBody`
@@ -158,7 +158,7 @@ where
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for CallBody<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> TryFrom<&'a [u8]> for CallBody<Opaque<&'a [u8]>, &'a [u8]> {
     type Error = Error;
 
     fn try_from(v: &'a [u8]) -> Result<Self, Self::Error> {
@@ -214,7 +214,7 @@ mod tests {
         let auth = AuthFlavor::AuthNone(Some(Opaque::from(binding.as_slice())));
         let payload = [42, 42, 42, 42];
 
-        let _call: CallBody<Opaque<'_, &[u8]>, &[u8; 4]> =
+        let _call: CallBody<Opaque<&[u8]>, &[u8; 4]> =
             CallBody::new(100000, 42, 13, auth.clone(), auth, &payload);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@
 mod errors;
 pub use errors::Error;
 
+mod opaque;
+pub use opaque::*;
+
 mod rpc_message;
 pub use rpc_message::*;
 

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,0 +1,178 @@
+use std::{
+    io::{Cursor, Write},
+    marker::PhantomData,
+};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::Error;
+
+// Opaque is a Variable-length Array that holds an uninterpreted byte array
+//https://datatracker.ietf.org/doc/html/rfc1014#section-3.12
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Opaque<'a, T>
+where
+    T: AsRef<[u8]>,
+{
+    body: T,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a> TryFrom<&mut Cursor<&'a [u8]>> for Opaque<'a, &'a [u8]> {
+    type Error = Error;
+
+    /// Deserialises a new [`Opaque`] from `cursor`.
+    fn try_from(c: &mut Cursor<&'a [u8]>) -> Result<Opaque<'a, &'a [u8]>, Self::Error> {
+        let len = c.read_u32::<BigEndian>()?;
+        let data = *c.get_ref();
+        let start = c.position() as usize;
+        let end = start + len as usize;
+        let padded_end = pad_length(len) + end as u32;
+
+        c.set_position(padded_end as u64);
+        Ok(Opaque {
+            body: &data[start..end],
+            phantom: PhantomData,
+        })
+    }
+}
+
+impl<'a, T> Opaque<'a, T>
+where
+    T: AsRef<[u8]> + Sized,
+{
+    pub fn from(data: T) -> Opaque<'a, T> {
+        Opaque {
+            body: data,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.body.as_ref().len()
+    }
+}
+
+impl<'a, T> AsRef<[u8]> for Opaque<'a, T>
+where
+    T: AsRef<[u8]> + Sized,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.body.as_ref()
+    }
+}
+
+pub trait SerializeOpaque {
+    fn serialise_into<W: Write>(&self, buf: &mut W) -> Result<(), std::io::Error>;
+
+    fn serialised_len(&self) -> u32;
+}
+
+impl<'a, T> SerializeOpaque for Opaque<'a, T>
+where
+    T: AsRef<[u8]> + Sized,
+{
+    /// Serialises this `Opaque` into `buf`, advancing the cursor position by
+    /// [`Opaque::serialised_len()`] bytes.
+    fn serialise_into<W: Write>(&self, buf: &mut W) -> Result<(), std::io::Error> {
+        let len = self.body.as_ref().len() as u32;
+        buf.write_u32::<BigEndian>(len)?;
+
+        let _ = buf.write_all(self.body.as_ref());
+        let fill_bytes = pad_length(len);
+        if fill_bytes > 0 {
+            buf.write_all(vec![0_u8; fill_bytes as usize].as_slice())?;
+        }
+        Ok(())
+    }
+
+    /// Returns the on-wire length of this opaque data once serialised.
+    fn serialised_len(&self) -> u32 {
+        let len = self.body.as_ref().len() as u32;
+        len + pad_length(len)
+    }
+}
+
+// https://datatracker.ietf.org/doc/html/rfc1014#section-4
+// (5) Why must variable-length data be padded with zeros?
+// It is desirable that the same data encode into the same thing on all
+// machines, so that encoded data can be meaningfully compared or
+// checksummed.  Forcing the padded bytes to be zero ensures this.
+#[inline]
+fn pad_length(l: u32) -> u32 {
+    if l % 4 == 0 {
+        return 0;
+    }
+    4 - (l % 4)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Cursor, marker::PhantomData};
+
+    use hex_literal::hex;
+
+    use crate::SerializeOpaque;
+
+    use super::Opaque;
+
+    #[test]
+    fn test_one_padded_opaque() {
+        // 1. deserialize
+        let raw = hex!("0000000f4c4150544f502d315151425044474d00").as_slice();
+        // opaque bytes from hex
+        let payload: [u8; 15] = [76, 65, 80, 84, 79, 80, 45, 49, 81, 81, 66, 80, 68, 71, 77];
+        let mut cursor = Cursor::new(raw);
+        let data = Opaque::try_from(&mut cursor).unwrap();
+        // 4 bytes + 15 bytes (payload) + 1 padding byte
+        assert_eq!(raw.len(), 20);
+        assert_eq!(data.as_ref().len(), 15);
+        assert!(data
+            .as_ref()
+            .iter()
+            .zip(payload.iter())
+            .all(|(a, b)| a == b));
+        let mydata = Vec::from(data.body);
+
+        // 2. erialize
+        let myopaque = Opaque {
+            body: mydata,
+            phantom: PhantomData,
+        };
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::<u8>::new());
+        let _ = myopaque.serialise_into(&mut buf);
+        assert_eq!(buf.get_ref().len(), 20);
+        // assert input == output
+        assert!(buf.get_ref().iter().zip(raw.iter()).all(|(a, b)| a == b));
+    }
+
+    #[test]
+    fn test_no_padded_opaque() {
+        // 1. deserialize
+        let raw = hex!("0000000c4c4150544f5151425044474d").as_slice();
+        // opaque bytes from hex
+        let payload: [u8; 12] = [76, 65, 80, 84, 79, 81, 81, 66, 80, 68, 71, 77];
+        let mut cursor = Cursor::new(raw);
+        let data = Opaque::try_from(&mut cursor).unwrap();
+        // 4 bytes + 12 bytes (payload)
+        assert_eq!(raw.len(), 16);
+        assert_eq!(data.as_ref().len(), 12);
+        assert!(data
+            .as_ref()
+            .iter()
+            .zip(payload.iter())
+            .all(|(a, b)| a == b));
+        let mydata = Vec::from(data.body);
+
+        // 2. serialize
+        let myopaque = Opaque {
+            body: mydata,
+            phantom: PhantomData,
+        };
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::<u8>::new());
+        let _ = myopaque.serialise_into(&mut buf);
+        assert_eq!(buf.get_ref().len(), 16);
+        // assert input == output
+        assert!(buf.get_ref().iter().zip(raw.iter()).all(|(a, b)| a == b));
+    }
+}

--- a/src/reply/accepted_reply.rs
+++ b/src/reply/accepted_reply.rs
@@ -26,7 +26,7 @@ where
     status: AcceptedStatus<P>,
 }
 
-impl<'a> AcceptedReply<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> AcceptedReply<Opaque<&'a [u8]>, &'a [u8]> {
     /// Constructs a new `AcceptedReply` by parsing the wire format read from
     /// `r`.
     ///
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for AcceptedReply<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> TryFrom<&'a [u8]> for AcceptedReply<Opaque<&'a [u8]>, &'a [u8]> {
     type Error = Error;
 
     fn try_from(v: &'a [u8]) -> Result<Self, Self::Error> {
@@ -272,7 +272,7 @@ mod tests {
         let auth = AuthFlavor::AuthNone(Some(Opaque::from(binding.as_slice())));
         let payload = [42, 42, 42, 42];
 
-        let _reply: AcceptedReply<Opaque<'_, &[u8]>, [u8; 4]> =
+        let _reply: AcceptedReply<Opaque<&[u8]>, [u8; 4]> =
             AcceptedReply::new(auth, AcceptedStatus::Success(payload));
     }
 }

--- a/src/reply/reply_body.rs
+++ b/src/reply/reply_body.rs
@@ -25,7 +25,7 @@ where
     Denied(RejectedReply),
 }
 
-impl<'a> ReplyBody<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> ReplyBody<Opaque<&'a [u8]>, &'a [u8]> {
     pub(crate) fn from_cursor(r: &mut Cursor<&'a [u8]>) -> Result<Self, Error> {
         match r.read_u32::<BigEndian>()? {
             REPLY_ACCEPTED => Ok(ReplyBody::Accepted(AcceptedReply::from_cursor(r)?)),
@@ -73,7 +73,7 @@ where
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for ReplyBody<Opaque<'a, &'a [u8]>, &'a [u8]> {
+impl<'a> TryFrom<&'a [u8]> for ReplyBody<Opaque<&'a [u8]>, &'a [u8]> {
     type Error = Error;
 
     fn try_from(v: &'a [u8]) -> Result<Self, Self::Error> {
@@ -111,7 +111,7 @@ mod tests {
         let auth = AuthFlavor::AuthNone(Some(Opaque::from(binding.as_slice())));
         let payload = [42, 42, 42, 42];
 
-        let _reply: ReplyBody<Opaque<'_, &[u8]>, [u8; 4]> = ReplyBody::Accepted(
+        let _reply: ReplyBody<Opaque<&[u8]>, [u8; 4]> = ReplyBody::Accepted(
             AcceptedReply::new(auth, crate::AcceptedStatus::Success(payload)),
         );
     }


### PR DESCRIPTION
This PR is based on [PR 27: fix: handle Opaque data correctly](https://github.com/domodwyer/onc-rpc/pull/27).
- Fixes `serialised_len` implementation for `AuthFlavor`.
- Removes unnecessary `PhantomData` for` Opaque` type.
- Updates the `SerializeOpaque` implementation to support `AsRef<[u8]>` directly, replacing the previous implementation that only supported `Opaque<'a, T>`.
Thanks to @Schille for the initial work in PR #27.